### PR TITLE
Update france_openair_standard.txt mod Poitiers3.1

### DIFF
--- a/france_openair_standard.txt
+++ b/france_openair_standard.txt
@@ -29,13 +29,7 @@
 
 ** (+)Ajout/Add (-)Suppression/Cancel (Mod)Modification
 
-
-****	+ AXE VOLTIGE 6383 + 6384
-****	+ ZONE PROTEGEE SOURROQUE-ARIEGE
-
-
-******* Mod R119
-*******	Mod ZSM FRANCE
+******* Mod Poitiers3.1
 
 
 
@@ -7871,6 +7865,8 @@ AH FL115
 AL 4000FT MSL
 DP 46:55:00 N 000:23:59 E
 DP 46:55:00 N 000:51:00 E
+DP 46:55:00 N 000:56:10 E
+DP 46:26:20 N 000:55:10 E
 DP 46:28:47 N 000:28:28 E
 DP 46:18:59 N 000:15:11 E
 V X=46:34:52 N 000:17:53 E

--- a/france_openair_standard.txt
+++ b/france_openair_standard.txt
@@ -29,6 +29,11 @@
 
 ** (+)Ajout/Add (-)Suppression/Cancel (Mod)Modification
 
+**** + AXE VOLTIGE 6383 + 6384
+**** + ZONE PROTEGEE SOURROQUE-ARIEGE
+
+******* Mod R119
+******* Mod ZSM FRANCE
 ******* Mod Poitiers3.1
 
 


### PR DESCRIPTION
TMA Poitiers 3.1
ajout 2 points manquant (côté Chauvigny)

source : AIP FRANCE  ENR 2.1 - 67  eaip-amdt A-2024-0418 APR 2024

TMA POITIERS partie 3-1
46°55'00"N , 000°23'59"E - 46°55'00"N , 000°51'00"E
- 46°55'00"N , 000°56'10"E - 46°26'20"N , 000°55'10"E
- 46°28'47"N , 000°28'28"E - 46°18'59"N , 000°15'11"E
- arc horaire de 16 NM de rayon centré sur 46°34'52"N
, 000°17'53"E - 46°24'42"N , 000°00'00"E - 46°30'00"N
, 000°00'00"E - 46°39'50"N , 000°00'00"E - 46°48'11"N
, 000°18'04"E - 46°55'00"N , 000°23'59"E
